### PR TITLE
Stylish CommandLine.hs and extract version to it's module

### DIFF
--- a/oczor.cabal
+++ b/oczor.cabal
@@ -1,5 +1,5 @@
 name:                oczor
-version:             0.0.0.1
+version:             0.0.1
 synopsis:            Oczor compiler
 description:         Please see README.md
 homepage:            https://github.com/ptol/oczor#readme
@@ -55,6 +55,7 @@ library
     Oczor.Test.TestCompiler
     Oczor.Test.Tests
     Oczor.Utl
+    Oczor.Version
   build-depends:
     base == 4.*,
     hspec == 2.*,

--- a/src/Oczor/Version.hs
+++ b/src/Oczor/Version.hs
@@ -1,0 +1,3 @@
+module Oczor.Version where
+
+version = "0.0.1"


### PR DESCRIPTION
* Sync version in command line description and cabal file
* Use stylish-haskell with default settings
* Use proper names and alphabetical order in parser options